### PR TITLE
:stars: add plugin method for expanding URLs

### DIFF
--- a/_add-ons/short_url/core.short_url.php
+++ b/_add-ons/short_url/core.short_url.php
@@ -5,24 +5,12 @@ require_once 'vendor/autoload.php';
 
 class Core_short_url extends Core
 {
-	private function ensureProtocol($url) {
-	    // Prepend "http://" to any link missing the HTTP protocol text.
-		if (preg_match('|^https*://|', $url) === 0) {
-			$url = 'http://' . $url . '/';
-		}
-
-		return $url;
-	}
-
 	public function getOverviewData() {
 		return array('shorturls' => $this->storage->getYAML('urls'));
 	}
 
 	public function create($url) {
 		$urls = $this->storage->getYAML('urls');
-
-		// put the http on it if needed
-		$url = $this->ensureProtocol($url);
 
 		// check to see if it exists already
 		$index = count($urls) ? array_search($url, array_column($urls, 'url')) : FALSE;

--- a/_add-ons/short_url/pi.short_url.php
+++ b/_add-ons/short_url/pi.short_url.php
@@ -24,4 +24,19 @@ class Plugin_short_url extends Plugin
         $url = $this->fetchParam('url');
         return $this->create($url);
     }
+
+
+
+
+
+    /**
+     * Expand a URL.
+     * @author Curtis Blackwell
+     * @return string The expanded URL.
+     */
+    public function expand()
+    {
+        $url = $this->fetchParam('url');
+        return $this->core->expand($url);
+    }
 }


### PR DESCRIPTION
Came across a use case for expanding URLs with the plugin:

I've got an app-like site I'm building that lists video, photo, and quote entries all together on the homepage. The quotes don't have a detail view, but they need to be share-able with a short URL. 

The short URL ends up looking like this: `/?quote=n`. Then I use this new plugin method to expand the GET var in `{{ get_content }}`.